### PR TITLE
feat: add all target to process all documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Sistema automatizado para recopilar, procesar y organizar documentos personales 
 
 ```bash
 # Pipeline completo
-python process_documents.py [--year 2025]
+python process_documents.py all [--year 2025]
 
 # Solo procesar tweets y PDFs
 python process_documents.py tweets pdfs

--- a/process_documents.py
+++ b/process_documents.py
@@ -3,7 +3,7 @@
 Procesa el pipeline de documentos.
 
 Uso:
-    python process_documents.py [--year 2026] [tweets|pdfs|podcasts|posts]
+    python process_documents.py [--year 2026] [tweets|pdfs|podcasts|posts|all]
 """
 import argparse
 from datetime import datetime
@@ -17,9 +17,12 @@ def parse_args():
     p = argparse.ArgumentParser()
     p.add_argument("--year", type=int,
                    help="Usa ese año en lugar del actual")
-    p.add_argument("targets", nargs="*",
-                   choices=["tweets", "pdfs", "podcasts", "posts"],
-                   help="Procesa solo los tipos indicados")
+    p.add_argument(
+        "targets",
+        nargs="+",
+        choices=["tweets", "pdfs", "podcasts", "posts", "all"],
+        help="Procesa solo los tipos indicados",
+    )
     return p.parse_args()
 
 
@@ -40,7 +43,7 @@ def main():
     # Crear procesador
     processor = DocumentProcessor(config)
 
-    if not args.targets:
+    if "all" in args.targets:
         success = processor.process_all()
     else:
         mapping = {

--- a/tests/test_process_documents_cli.py
+++ b/tests/test_process_documents_cli.py
@@ -60,3 +60,8 @@ def test_selective_processing(monkeypatch, tmp_path):
     calls = run_main(monkeypatch, tmp_path, ["tweets", "pdfs"])
     assert calls == ["tweets", "pdfs", "register"]
 
+
+def test_all_processing(monkeypatch, tmp_path):
+    calls = run_main(monkeypatch, tmp_path, ["all"])
+    assert calls == ["all"]
+


### PR DESCRIPTION
## Summary
- allow `all` as a CLI target to process every document type
- document new `all` option in README and tests

## Testing
- `python -m py_compile process_documents.py tests/test_process_documents_cli.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68a5a153ba548322bd9650fe916a0f47