### PR TITLE
Simplify HTML processing and centralize helpers

### DIFF
--- a/pdf_processor.py
+++ b/pdf_processor.py
@@ -30,5 +30,5 @@ class PDFProcessor:
         
         if moved_pdfs:
             print(f"📚 {len(moved_pdfs)} PDF(s) movidos a {self.destination_dir}")
-        
-        return moved_pdfs 
+
+        return moved_pdfs

--- a/podcast_processor.py
+++ b/podcast_processor.py
@@ -166,21 +166,9 @@ class PodcastProcessor:
                 print(f"❌ Error convirtiendo {md_file}: {e}")
     
     def _md_to_html(self, md_text: str) -> str:
-        """Convierte texto Markdown en HTML usando funciones centralizadas."""
-        return U.markdown_to_html(md_text).split('<body>\n')[1].split('\n</body>')[0]
+        """Convierte texto Markdown en HTML y devuelve solo el contenido."""
+        return U.markdown_to_html_body(md_text)
     
     def _wrap_html(self, title: str, body: str) -> str:
-        """Devuelve un documento HTML con cabecera mínima, UTF-8 y estilos CSS."""
-        return (
-            "<!DOCTYPE html>\n"
-            "<html>\n<head>\n<meta charset=\"UTF-8\">\n"
-            f"<title>{title}</title>\n"
-            "<style>\n"
-            f"{U.get_base_css()}"
-            "blockquote { border-left: 4px solid #667eea; }\n"
-            "a { color: #667eea; }\n"
-            "</style>\n"
-            "</head>\n<body>\n"
-            f"{body}\n"
-            "</body>\n</html>\n"
-        ) 
+        """Envuelve el contenido en un HTML con estilos y color de podcast."""
+        return U.wrap_html(title, body, "#667eea")

--- a/tweet_processor.py
+++ b/tweet_processor.py
@@ -69,15 +69,9 @@ class TweetProcessor:
             # Leer contenido Markdown
             md_text = md_file.read_text(encoding="utf-8")
             
-            # Convertir a HTML usando las utilidades existentes
-            html_body = U.markdown_to_html(md_text)
-            
-            # Extraer solo el contenido del body
-            if '<body>' in html_body and '</body>' in html_body:
-                body_content = html_body.split('<body>')[1].split('</body>')[0].strip()
-            else:
-                body_content = html_body
-            
+            # Convertir a HTML y extraer el cuerpo
+            body_content = U.markdown_to_html_body(md_text)
+
             # Crear HTML completo con estructura mínima
             full_html = self._wrap_html(md_file.stem, body_content)
             
@@ -94,19 +88,7 @@ class TweetProcessor:
 
     def _wrap_html(self, title: str, body: str) -> str:
         """Crea un documento HTML completo con título y estilos básicos."""
-        return (
-            "<!DOCTYPE html>\n"
-            "<html>\n<head>\n<meta charset=\"UTF-8\">\n"
-            f"<title>{title}</title>\n"
-            "<style>\n"
-            f"{U.get_base_css()}"
-            "blockquote { border-left: 4px solid #1DA1F2; }\n"
-            "a { color: #1DA1F2; }\n"
-            "</style>\n"
-            "</head>\n<body>\n"
-            f"{body}\n"
-            "</body>\n</html>\n"
-        )
+        return U.wrap_html(title, body, "#1DA1F2")
     
     def _move_files_with_replacement(self, files: List[Path], dest: Path) -> List[Path]:
         """Mueve archivos al destino, reemplazando archivos existentes con el mismo nombre."""
@@ -126,5 +108,5 @@ class TweetProcessor:
             # Mover el nuevo archivo
             shutil.move(str(f), new_path)
             moved.append(new_path)
-        
-        return moved 
+
+        return moved

--- a/utils.py
+++ b/utils.py
@@ -374,8 +374,19 @@ def markdown_to_html(md_text: str, title: str = None) -> str:
         f"{html_body}\n"
         "</body>\n</html>\n"
     )
-    
+
     return full_html
+
+
+def extract_html_body(html: str) -> str:
+    """Extrae el contenido dentro de la etiqueta <body>."""
+    body = re.search(r"<body>(.*)</body>", html, re.DOTALL | re.IGNORECASE)
+    return body.group(1).strip() if body else html
+
+
+def markdown_to_html_body(md_text: str, title: str = None) -> str:
+    """Convierte Markdown a HTML y devuelve solo el contenido del <body>."""
+    return extract_html_body(markdown_to_html(md_text, title))
 
 
 def get_base_css() -> str:
@@ -387,4 +398,21 @@ def get_base_css() -> str:
         "a { text-decoration: none; }\n"
         "a:hover { text-decoration: underline; }\n"
         "hr { border: none; border-top: 1px solid #eee; margin: 30px 0; }\n"
+    )
+
+
+def wrap_html(title: str, body: str, accent_color: str) -> str:
+    """Envuelve contenido en un HTML mínimo con estilos base y color destacado."""
+    return (
+        "<!DOCTYPE html>\n"
+        "<html>\n<head>\n<meta charset=\"UTF-8\">\n"
+        f"<title>{title}</title>\n"
+        "<style>\n"
+        f"{get_base_css()}"
+        f"blockquote {{ border-left: 4px solid {accent_color}; }}\n"
+        f"a {{ color: {accent_color}; }}\n"
+        "</style>\n"
+        "</head>\n<body>\n"
+        f"{body}\n"
+        "</body>\n</html>\n"
     )


### PR DESCRIPTION
## Summary
- Consolidate HTML body extraction and wrapping helpers in `utils` to remove duplication
- Update podcast and tweet processors to leverage new helpers for cleaner HTML generation
- Minor cleanup in pdf processor

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests markdown -q` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_68a7680444b48322a5c678e87585c2d6