### PR TITLE
Serve /read/ via autoindex and build read.html listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ La carpeta `web/` contiene la infraestructura y el contenido estático que se pu
 
 - Contenido público: `web/public/`
   - Ruta pública: `/read/` (HTML + PDFs combinados).
-  - Los índices `index.html` se generan en cada deploy, ordenados por `mtime` desc; los bumpeados (fecha futura) suben arriba.
+  - `read.html` se genera en cada deploy, ordenado por `mtime` desc; el directorio se sirve con el listado automático de nginx.
   - El overlay de `utils/serve_docs.py` publica/despublica copiando o borrando archivos en `web/public/read/` y ejecutando el deploy.
 - Deploy: `web/deploy.sh`
   - Requiere `REMOTE_USER` y `REMOTE_HOST` en el entorno.
@@ -218,15 +218,15 @@ Variables de entorno:
 - Deploy: `REMOTE_USER` y `REMOTE_HOST` (requeridos por `web/deploy.sh`; el script hereda estas variables y debe ser ejecutable con `chmod +x web/deploy.sh`)
  - Deploy (opcional, gestión de BasicAuth): si defines `HTPASSWD_USER` y `HTPASSWD_PSS`, el deploy actualizará `/opt/web-domingo/nginx/.htpasswd` en el host generando un hash bcrypt (la contraseña viaja por `stdin`, no se muestra en `argv`).
 
-Índices estáticos en el deploy:
-- `web/deploy.sh` regenera el índice para `/read/` (HTML/PDF). Orden por `mtime` desc.
+Listado estático en el deploy:
+- `web/deploy.sh` genera `read.html` para `/read/` (HTML/PDF) ordenado por `mtime` desc.
 
 Solución de problemas:
 - “Publicar” no aparece: el archivo no está bumpeado o ya existe en `PUBLIC_READS_DIR`. Comprueba `mtime` y que el nombre no exista en destino.
 - “Despublicar” no aparece: el archivo no está en `PUBLIC_READS_DIR` (detección por nombre). Revisa `PUBLIC_READS_DIR` efectivo.
 - Error al publicar/desplegar: mira la consola de `serve_docs.py` para el detalle. Asegura `chmod +x web/deploy.sh` y exporta `REMOTE_USER`/`REMOTE_HOST`.
 - Toast sin enlace “Ver”: define `PUBLIC_READS_URL_BASE`.
-- Índice de `/read/` no cambia: el deploy regenera `index.html`. Fuerza recarga. Verifica que `web/deploy.sh` terminó sin errores.
+- `read.html` no cambia: el deploy lo regenera. Fuerza recarga. Verifica que `web/deploy.sh` terminó sin errores.
 
 ## 📌 Scripts principales
 
@@ -267,7 +267,7 @@ Sitio en producción: https://domingogallardo.com
 Este repo incluye una configuración opcional para servir tu contenido procesado en un servidor propio:
 
 - Directorio `web/` (infra):
-  - `Dockerfile` y `nginx.conf`: Imagen Nginx (Alpine) que sirve HTML/PDF y expone `/read/` mediante índice estático generado en el deploy, ordenado por fecha (mtime desc). Provee `/data/` para ediciones vía PUT protegido con BasicAuth.
+  - `Dockerfile` y `nginx.conf`: Imagen Nginx (Alpine) que sirve HTML/PDF y expone `/read/` con listado automático; `read.html` se genera en el deploy ordenado por fecha (mtime desc). Provee `/data/` para ediciones vía PUT protegido con BasicAuth.
   - `docker-compose.yml` (solo local): monta `./public` y `./dynamic-data` en modo lectura (`:ro`) y expone `8080:80`.
   - `deploy.sh`: empaqueta y despliega al servidor remoto en `/opt/web-domingo` y levanta el contenedor `web-domingo`. Requiere `REMOTE_USER` y `REMOTE_HOST` (no se incluyen secretos en el repo).
   - `.dockerignore` para builds reproducibles.

--- a/tests/test_deploy_read_html.py
+++ b/tests/test_deploy_read_html.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import os
+import subprocess
+
+def _extract_python_snippet() -> str:
+    repo_root = Path(__file__).resolve().parents[1]
+    script = (repo_root / "web" / "deploy.sh").read_text(encoding="utf-8")
+    start = script.index("<< 'PY'\n") + len("<< 'PY'\n")
+    end = script.index("\nPY", start)
+    return script[start:end]
+
+def test_gen_index_creates_read_html(tmp_path):
+    snippet = _extract_python_snippet()
+    (tmp_path / "a.html").write_text("<p>A</p>", encoding="utf-8")
+    (tmp_path / "b.pdf").write_bytes(b"%PDF-1.4\n")
+    env = os.environ.copy()
+    env.update({
+        "DIR_PATH": str(tmp_path),
+        "TITLE": "Read",
+        "EXT_FILTER": ".html,.pdf",
+    })
+    subprocess.run(["python3", "-"], input=snippet, text=True, env=env, check=True)
+    read_file = tmp_path / "read.html"
+    assert read_file.exists()
+    assert not (tmp_path / "index.html").exists()
+    content = read_file.read_text(encoding="utf-8")
+    assert "read.html" not in content

--- a/tests/test_nginx_read_autoindex.py
+++ b/tests/test_nginx_read_autoindex.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+def test_read_location_has_autoindex(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    cfg = (repo_root / "web" / "nginx.conf").read_text(encoding="utf-8").splitlines()
+    inside = False
+    autoindex = False
+    for line in cfg:
+        stripped = line.strip()
+        if stripped.startswith("location /read/"):
+            inside = True
+            continue
+        if inside:
+            if stripped.startswith("}"):
+                break
+            if "autoindex" in stripped:
+                autoindex = "on" in stripped
+            assert "try_files" not in stripped
+            assert stripped != "index index.html;"
+    assert autoindex

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,8 +1,8 @@
 # [APP] NGINX-App (CONTENEDOR)
 # Imagen que sirve la web estática y listados ordenados por fecha.
 # - Base: Alpine 3.20. Se instalan NGINX y tzdata desde apk. Zona horaria: Europe/Madrid.
-# - Función [APP]: servir / (HTML/PDF), exponer /read con índice estático por mtime desc
-#   (generado en el deploy) y habilitar WebDAV en /data (PUT) con BasicAuth usando un .htpasswd montado.
+# - Función [APP]: servir / (HTML/PDF), exponer /read con listado automático
+#   (read.html ordenado por mtime desc generado en el deploy) y habilitar WebDAV en /data (PUT) con BasicAuth usando un .htpasswd montado.
 #
 # Despliegue en DigitalOcean con doble NGINX (domingogallardo.com):
 # - [PROXY] NGINX-Proxy (HOST): termina TLS (Let’s Encrypt), redirige 80→443 y
@@ -13,7 +13,7 @@
 #     - /opt/web-domingo/nginx/.htpasswd → /etc/nginx/.htpasswd (ro) ← credenciales BasicAuth
 #   La configuración de [APP] está en /etc/nginx/nginx.conf.
 #
-# Nota: el índice de /read se genera en web/deploy.sh.
+# Nota: el fichero read.html se genera en web/deploy.sh.
 # El [PROXY] solo enruta; la autenticación de escritura se aplica en [APP].
 
 FROM alpine:3.20

--- a/web/deploy.sh
+++ b/web/deploy.sh
@@ -13,11 +13,11 @@ fi
 REMOTE_PATH="/opt/web-domingo"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Generador de índices estáticos (lista simple con fecha, sin CSS)
+# Generador de listados estáticos (lista simple con fecha, sin CSS)
 gen_index() {
   local DIR_PATH="$1"; local TITLE="$2"; local EXT_FILTER="$3"
   if [[ -d "$DIR_PATH" ]]; then
-    echo "🧾 Generando índice estático de ${TITLE} (mtime desc)..."
+    echo "🧾 Generando listado estático de ${TITLE} (mtime desc)..."
     PYTHON_BIN="python3"; command -v python3 >/dev/null 2>&1 || PYTHON_BIN=python
     DIR_PATH="$DIR_PATH" TITLE="$TITLE" EXT_FILTER="$EXT_FILTER" "$PYTHON_BIN" - << 'PY'
 import os, sys, time, html
@@ -36,7 +36,7 @@ for name in os.listdir(dir_path):
     path = os.path.join(dir_path, name)
     if not os.path.isfile(path): continue
     low = name.lower()
-    if low in ('index.html','index.htm'): continue
+    if low in ('read.html','index.html','index.htm'): continue
     if allowed and not low.endswith(allowed): continue
     st = os.stat(path)
     entries.append((st.st_mtime, name))
@@ -92,14 +92,14 @@ f'<h1>{html.escape(title)}</h1>'
 '</body></html>'
 )
 
-out = os.path.join(dir_path, 'index.html')
+out = os.path.join(dir_path, 'read.html')
 with open(out, 'w', encoding='utf-8') as f: f.write(html_doc)
 print(f"✓ Generado {out}")
 PY
   fi
 }
 
-# Generar índice para /read (HTML+PDF combinados)
+# Generar read.html para /read (HTML+PDF combinados)
 gen_index "$SCRIPT_DIR/public/read" "Read" ".html,.htm,.pdf"
 
 echo "📦 Empaquetando archivos (sin metadatos de macOS)..."

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -50,8 +50,7 @@ http {
         }
         location /read/ {
             alias /usr/share/nginx/html/read/;
-            index index.html;
-            try_files $uri $uri/ /read/index.html;
+            autoindex on;
         }
 
         # /papers: PDFs propios (gestionado fuera del repo)


### PR DESCRIPTION
## Summary
- generate `read.html` during deploy and exclude it from listings
- serve `/read/` through nginx autoindex instead of static `index.html`
- document new behavior and add tests for deploy snippet and nginx config

## Testing
- `pip install requests beautifulsoup4 markdownify anthropic pillow pytest markdown` *(fails: Could not connect to proxy)*
- `pytest -v` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68bac125bb348322a37262968111456a