### PR TITLE
fix: improve iOS clipboard compatibility for article quotes

### DIFF
--- a/web/public/read/article.js
+++ b/web/public/read/article.js
@@ -42,8 +42,17 @@
       } catch (_) {}
       try {
         var ta = document.createElement('textarea');
-        ta.value = text; ta.setAttribute('readonly',''); ta.style.position='fixed'; ta.style.opacity='0'; ta.style.top='-1000px';
-        document.body.appendChild(ta); ta.select();
+        ta.value = text;
+        ta.setAttribute('readonly','');
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        ta.style.top = '-1000px';
+        ta.style.left = '-1000px';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        // Safari iOS needs explicit range selection
+        try { ta.setSelectionRange(0, ta.value.length); } catch (_) {}
         var ok = false;
         try { ok = document.execCommand('copy'); } catch (_) { ok = false; }
         document.body.removeChild(ta);


### PR DESCRIPTION
## Summary
- focus hidden textarea and select full range before calling `execCommand` to support iOS Safari clipboard copy

## Testing
- `pip install requests beautifulsoup4 markdownify anthropic pillow pytest markdown` *(fails: Could not find a version that satisfies the requirement requests)*
- `pytest -v` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68c109b729e08322a54ac0b04a62fa63